### PR TITLE
added a new command to list go versions

### DIFF
--- a/gvm.sh
+++ b/gvm.sh
@@ -64,7 +64,7 @@ gvm_releases_cache_file() {
 }
 
 gvm_releases_parse() {
-	grep -Po "https://dl.google.com/go/go[^>\"]+" $(gvm_releases_cache_file) | grep -Po "go[^/\-a-z]+" | sed -e "s/.$//g" | sort -u
+	grep -Po "https://dl.google.com/go/go[^>\"]+" $(gvm_releases_cache_file) | grep -Po "go[^/\-a-z]+" | sed -e "s/.$//g" | sed -e "s/^go//g" | sort -u
 }
 
 gvm_releases_update_cache() {

--- a/gvm.sh
+++ b/gvm.sh
@@ -374,6 +374,8 @@ gvm_help() {
     gvm_echo '  gvm uninstall <version>         Uninstall a <version>'        
     gvm_echo '  gvm use <version>               Modify PATH to use <version>'
     gvm_echo '  gvm current                     Display currently activated version'
+    gvm_echo '  gvm releases                    Display available release versions to install'
+    gvm_echo '  gvm flush                       Remove the cache file used in gvm releases'
     gvm_echo '  gvm ls                          List installed versions'
     gvm_echo
     gvm_echo 'Example:'

--- a/gvm.sh
+++ b/gvm.sh
@@ -364,7 +364,7 @@ gvm_ls() {
 }
 
 gvm_version() {
-    gvm_echo 'v0.1.0'
+    gvm_echo 'v0.1.1'
 }
 
 gvm_deactivate() {

--- a/gvm.sh
+++ b/gvm.sh
@@ -88,7 +88,6 @@ gvm_releases_cache_expired() {
 }
 
 gvm_releases() {
-	set -x
 	IS_CACHE=$([ -f $(gvm_releases_cache_file) ] && gvm_echo 1 || gvm_echo 0)
 	CACHE_EXPIRED=$([ $IS_CACHE -eq 1 ] && $(gvm_releases_cache_expired) || gvm_echo 1)
 	[ $CACHE_EXPIRED -eq 0 ] || gvm_releases_update_cache

--- a/gvm.sh
+++ b/gvm.sh
@@ -81,17 +81,21 @@ gvm_releases_cache_expired() {
 	NOW_TS=$(date +"%s")
 	CACHE_AGE=$(expr $NOW_TS - $CACHE_TS)
 	if [ $(gvm_releases_cache_ttl) -lt $CACHE_AGE ]; then
-		return 1
+		return "1"
 	else
-		return 0
+		return "0"
 	fi
 }
 
 gvm_releases() {
 	IS_CACHE=$([ -f $(gvm_releases_cache_file) ] && gvm_echo 1 || gvm_echo 0)
-	CACHE_EXPIRED=$([ $IS_CACHE -eq 1 ] && $(gvm_releases_cache_expired) || gvm_echo 1)
+	CACHE_EXPIRED=$([ $IS_CACHE -eq 1 ] && gvm_releases_cache_expired; gvm_echo $?)
 	[ $CACHE_EXPIRED -eq 0 ] || gvm_releases_update_cache
 	gvm_releases_parse
+}
+
+gvm_flush() {
+	rm $(gvm_releases_cache_file)
 }
 
 gvm_download() {
@@ -449,6 +453,9 @@ gvm() {
         ;;
         'ls' )
             gvm_ls
+        ;;
+        'flush' )
+            gvm_flush
         ;;
         'releases' )
             gvm_releases

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ gvm_install_dir() {
 }
 
 gvm_latest_version() {
-    gvm_echo "v0.1.0"
+    gvm_echo "v0.1.1"
 }
 
 gvm_source() {


### PR DESCRIPTION
added a command to list available go versions. 

i tried the approach using GitHub releases API for golang/go repo but that approach didn't work always returned empty resultset. This approach even though it's parsing the HTML file in the main download directory. It seems to work ok. I added a default cache of 3600 seconds. It can increase too if needed.  

usage 

```gvm releases```

and it prints all the releases available to download. It's using a caching mechanism to not always download the HTML file. I believe I followed your naming convention-style if there is an issue with that let me know. 


